### PR TITLE
Added .gitignore file for IntelliJ projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+**/.idea
+**/out
+*.iml
+*.class
+.ipynb_checkpoints/
+.DS_Store
+.envrc
+.env
+**/.vscode/**


### PR DESCRIPTION
I think having a .gitignore file would be helpful since IntelliJ would otherwise mark all the out/ and .idea/ directories as untracked, which might cause eventual confusion for students.